### PR TITLE
feat: add backup details drawer

### DIFF
--- a/app_backup_import.go
+++ b/app_backup_import.go
@@ -24,12 +24,17 @@ import (
 
 // PeekBackupInfo opens a backup DB file read-only and returns a summary of its contents.
 func (a *App) PeekBackupInfo(path string) (*models.BackupPeekInfo, error) {
-	log := logger.WithComponent("app")
-	log.Info("peeking backup info", slog.String("path", path))
-
 	if err := validateBackupPath(path); err != nil {
 		return nil, err
 	}
+	return peekBackupAtPath(path)
+}
+
+// peekBackupAtPath opens a backup DB file read-only and returns a summary of its
+// contents. Callers are responsible for validating/authorizing the path first.
+func peekBackupAtPath(path string) (*models.BackupPeekInfo, error) {
+	log := logger.WithComponent("app")
+	log.Info("peeking backup info", slog.String("path", path))
 
 	backupDB, err := openBackupDB(path)
 	if err != nil {
@@ -44,25 +49,17 @@ func (a *App) PeekBackupInfo(path string) (*models.BackupPeekInfo, error) {
 	info.SchemaVersion = int(version)
 	log.Info("backup schema version", slog.Uint64("version", uint64(version)), slog.Bool("dirty", dirty))
 
-	// Get certificate count and hostnames
-	rows, err := backupDB.Query("SELECT hostname FROM certificates ORDER BY hostname")
+	// Get certificate details (hostname, status, SANs, created/expires)
+	certs, err := readBackupCertificates(backupDB)
 	if err != nil {
 		log.Error("failed to query backup certificates", logger.Err(err))
 		return nil, fmt.Errorf("failed to read backup certificates: %w", err)
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var hostname string
-		if err := rows.Scan(&hostname); err != nil {
-			return nil, fmt.Errorf("failed to scan hostname: %w", err)
-		}
-		info.Hostnames = append(info.Hostnames, hostname)
+	info.Certificates = certs
+	for _, c := range certs {
+		info.Hostnames = append(info.Hostnames, c.Hostname)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate hostnames: %w", err)
-	}
-	info.CertificateCount = len(info.Hostnames)
+	info.CertificateCount = len(certs)
 
 	// Get CA name from config
 	var caName sql.NullString
@@ -81,6 +78,9 @@ func (a *App) PeekBackupInfo(path string) (*models.BackupPeekInfo, error) {
 	if info.Hostnames == nil {
 		info.Hostnames = []string{}
 	}
+	if info.Certificates == nil {
+		info.Certificates = []models.BackupCertificateInfo{}
+	}
 
 	log.Info("backup peek complete",
 		slog.Int("certificates", info.CertificateCount),
@@ -90,6 +90,72 @@ func (a *App) PeekBackupInfo(path string) (*models.BackupPeekInfo, error) {
 	)
 
 	return info, nil
+}
+
+// readBackupCertificates reads all certificates from a backup DB (opened read-only)
+// and returns their display fields: status, SANs, key size, created/expires. Only
+// public data (certificate PEM / pending CSR) is parsed — no master key is needed.
+func readBackupCertificates(backupDB *sql.DB) ([]models.BackupCertificateInfo, error) {
+	rows, err := backupDB.Query(
+		"SELECT hostname, certificate_pem, pending_csr_pem, created_at, expires_at FROM certificates ORDER BY hostname",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.BackupCertificateInfo
+	for rows.Next() {
+		var (
+			hostname   string
+			certPEM    sql.NullString
+			pendingCSR sql.NullString
+			createdAt  int64
+			expiresAt  sql.NullInt64
+		)
+		if err := rows.Scan(&hostname, &certPEM, &pendingCSR, &createdAt, &expiresAt); err != nil {
+			return nil, fmt.Errorf("failed to scan certificate: %w", err)
+		}
+
+		// Reuse the shared status computation by reconstructing a sqlc row.
+		status := db.ComputeStatus(&dbsqlc.Certificate{
+			Hostname:       hostname,
+			CertificatePem: certPEM,
+			PendingCsrPem:  pendingCSR,
+			CreatedAt:      createdAt,
+			ExpiresAt:      expiresAt,
+		})
+
+		info := models.BackupCertificateInfo{
+			Hostname:  hostname,
+			Status:    string(status),
+			CreatedAt: createdAt,
+		}
+		if expiresAt.Valid {
+			e := expiresAt.Int64
+			info.ExpiresAt = &e
+		}
+
+		// SANs + key size: from the signed certificate if present, else the pending CSR.
+		if certPEM.Valid && certPEM.String != "" {
+			if cert, err := crypto.ParseCertificate([]byte(certPEM.String)); err == nil {
+				if details, _ := crypto.ExtractCertificateDetails(cert); details != nil {
+					info.SANs = details.SANs
+					info.KeySize = details.KeySize
+				}
+			}
+		} else if pendingCSR.Valid && pendingCSR.String != "" {
+			if csr, err := crypto.ParseCSR([]byte(pendingCSR.String)); err == nil {
+				if details, _ := crypto.ExtractCSRDetails(csr); details != nil {
+					info.SANs = details.SANs
+					info.KeySize = details.KeySize
+				}
+			}
+		}
+
+		out = append(out, info)
+	}
+	return out, rows.Err()
 }
 
 // ImportCertificatesFromBackup selectively imports certificates from a backup DB file.

--- a/app_backups.go
+++ b/app_backups.go
@@ -19,6 +19,19 @@ import (
 // Local Backup Operations
 // ============================================================================
 
+// validateLocalBackupFilename ensures a filename refers to a known local backup
+// file: only the recognized prefixes, with no path-traversal characters.
+func validateLocalBackupFilename(filename string) error {
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		return fmt.Errorf("invalid backup filename")
+	}
+	if !strings.HasPrefix(filename, "certificates.db.autobackup.") &&
+		!strings.HasPrefix(filename, "certificates.db.backup.manual.") {
+		return fmt.Errorf("invalid backup filename")
+	}
+	return nil
+}
+
 // ListLocalBackups returns metadata for all local database backup files.
 func (a *App) ListLocalBackups() ([]models.LocalBackupInfo, error) {
 	a.mu.RLock()
@@ -30,6 +43,26 @@ func (a *App) ListLocalBackups() ([]models.LocalBackupInfo, error) {
 	}
 
 	return autoBackup.ListBackups()
+}
+
+// PeekLocalBackup opens a local backup file read-only and returns a summary of
+// its contents (certificate count, hostnames, CA name, schema version, whether it
+// carries security keys). Used by the backup details drawer.
+func (a *App) PeekLocalBackup(filename string) (*models.BackupPeekInfo, error) {
+	if err := a.requireSetupOnly(); err != nil {
+		return nil, err
+	}
+
+	if err := validateLocalBackupFilename(filename); err != nil {
+		return nil, err
+	}
+
+	backupPath := filepath.Join(a.dataDir, "backups", filename)
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("backup file not found")
+	}
+
+	return peekBackupAtPath(backupPath)
 }
 
 // CreateManualBackup creates a manual database backup snapshot.
@@ -74,13 +107,8 @@ func (a *App) RestoreLocalBackup(filename string) error {
 	log := logger.WithComponent("app")
 	log.Info("restoring from local backup", slog.String("filename", filename))
 
-	// Validate filename: only known prefixes, no path traversal
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
-		return fmt.Errorf("invalid backup filename")
-	}
-	if !strings.HasPrefix(filename, "certificates.db.autobackup.") &&
-		!strings.HasPrefix(filename, "certificates.db.backup.manual.") {
-		return fmt.Errorf("invalid backup filename")
+	if err := validateLocalBackupFilename(filename); err != nil {
+		return err
 	}
 
 	backupPath := filepath.Join(a.dataDir, "backups", filename)

--- a/app_backups_test.go
+++ b/app_backups_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ============================================================================
+// PeekLocalBackup
+// ============================================================================
+
+// stageLocalBackup creates a backup .db file under the app's backups directory
+// and returns its filename.
+func stageLocalBackup(t *testing.T, app *App, filename string, opts testBackupDBOpts) string {
+	t.Helper()
+
+	srcPath, _ := createTestBackupDB(t, opts)
+
+	backupsDir := filepath.Join(app.dataDir, "backups")
+	if err := os.MkdirAll(backupsDir, 0o755); err != nil {
+		t.Fatalf("failed to create backups dir: %v", err)
+	}
+	if err := copyFile(srcPath, filepath.Join(backupsDir, filename)); err != nil {
+		t.Fatalf("failed to stage backup: %v", err)
+	}
+	return filename
+}
+
+func TestPeekLocalBackup_ManualBackup(t *testing.T) {
+	app, _ := setupFileBasedApp(t)
+
+	filename := stageLocalBackup(t, app, "certificates.db.backup.manual.20260615-120000.db", testBackupDBOpts{
+		hostnames: []string{"alpha.example.com", "bravo.example.com"},
+		password:  testPassword,
+		caName:    "My CA",
+	})
+
+	info, err := app.PeekLocalBackup(filename)
+	if err != nil {
+		t.Fatalf("PeekLocalBackup() error: %v", err)
+	}
+
+	if info.CertificateCount != 2 {
+		t.Fatalf("expected 2 certificates, got %d", info.CertificateCount)
+	}
+	if info.CAName != "My CA" {
+		t.Fatalf("expected CA name 'My CA', got %q", info.CAName)
+	}
+	if !info.HasSecurityKeys {
+		t.Fatal("expected has_security_keys=true")
+	}
+	if info.SchemaVersion != 4 {
+		t.Fatalf("expected schema_version=4, got %d", info.SchemaVersion)
+	}
+
+	// Per-certificate details should be populated for the drawer.
+	if len(info.Certificates) != 2 {
+		t.Fatalf("expected 2 certificate entries, got %d", len(info.Certificates))
+	}
+	for _, c := range info.Certificates {
+		if c.Hostname == "" {
+			t.Fatal("certificate entry missing hostname")
+		}
+		if c.CreatedAt == 0 {
+			t.Fatalf("certificate %q missing created_at", c.Hostname)
+		}
+		// Test backups insert certs without a signed PEM/CSR → pending.
+		if c.Status != "pending" {
+			t.Fatalf("certificate %q: expected status pending, got %q", c.Hostname, c.Status)
+		}
+	}
+}
+
+func TestPeekLocalBackup_AutoBackup(t *testing.T) {
+	app, _ := setupFileBasedApp(t)
+
+	filename := stageLocalBackup(t, app, "certificates.db.autobackup.20260615-120000.db", testBackupDBOpts{
+		certCount: 1,
+	})
+
+	info, err := app.PeekLocalBackup(filename)
+	if err != nil {
+		t.Fatalf("PeekLocalBackup() error: %v", err)
+	}
+	if info.CertificateCount != 1 {
+		t.Fatalf("expected 1 certificate, got %d", info.CertificateCount)
+	}
+}
+
+func TestPeekLocalBackup_RejectsInvalidFilenames(t *testing.T) {
+	app, _ := setupFileBasedApp(t)
+
+	cases := []string{
+		"../certificates.db",                       // path traversal
+		"backups/certificates.db.backup.manual.db", // contains separator
+		"certificates.db",                          // not a backup prefix
+		"random-file.db",                           // unrelated file
+	}
+
+	for _, name := range cases {
+		if _, err := app.PeekLocalBackup(name); err == nil {
+			t.Fatalf("expected error for invalid filename %q, got nil", name)
+		}
+	}
+}
+
+func TestPeekLocalBackup_MissingFile(t *testing.T) {
+	app, _ := setupFileBasedApp(t)
+
+	// Valid prefix, but the file does not exist on disk.
+	_, err := app.PeekLocalBackup("certificates.db.backup.manual.20260615-120000.db")
+	if err == nil {
+		t.Fatal("expected error for non-existent backup file")
+	}
+}

--- a/frontend/src/components/settings/BackupDetailsDrawer.tsx
+++ b/frontend/src/components/settings/BackupDetailsDrawer.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useState } from "react";
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { AdminGatedButton } from "@/components/shared/AdminGatedButton";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { StatusBadge } from "@/components/certificate/StatusBadge";
+import { useBackup } from "@/hooks/useBackup";
+import {
+    formatDate,
+    formatDateTime,
+    getRelativeTime,
+    formatFileSize,
+} from "@/lib/theme";
+import { LocalBackupInfo, BackupPeekInfo } from "@/types";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+    Delete02Icon,
+    DatabaseRestoreIcon,
+    DatabaseIcon,
+} from "@hugeicons/core-free-icons";
+
+interface BackupDetailsDrawerProps {
+    backup: LocalBackupInfo | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onRestore: (filename: string) => void;
+    onDelete: (filename: string) => void;
+    isLoading: boolean;
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+    return (
+        <div className="flex items-center justify-between gap-4 py-1.5">
+            <span className="text-xs text-muted-foreground">{label}</span>
+            <span className="text-xs font-medium text-foreground text-right">
+                {value}
+            </span>
+        </div>
+    );
+}
+
+export function BackupDetailsDrawer({
+    backup,
+    open,
+    onOpenChange,
+    onRestore,
+    onDelete,
+    isLoading,
+}: BackupDetailsDrawerProps) {
+    const { peekLocalBackup } = useBackup();
+    const [info, setInfo] = useState<BackupPeekInfo | null>(null);
+    const [isPeeking, setIsPeeking] = useState(false);
+    const [peekError, setPeekError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!open || !backup) return;
+
+        let cancelled = false;
+        setInfo(null);
+        setPeekError(null);
+        setIsPeeking(true);
+
+        peekLocalBackup(backup.filename)
+            .then((result) => {
+                if (cancelled) return;
+                if (result) {
+                    setInfo(result);
+                } else {
+                    setPeekError("Could not read this backup's contents.");
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setIsPeeking(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+        // peekLocalBackup is stable for the drawer's lifetime
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, backup?.filename]);
+
+    const isManual = backup?.type === "manual";
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side="right"
+                className="top-16 bottom-0 h-[calc(100%-4rem)]"
+            >
+                <SheetHeader>
+                    <div className="flex items-center gap-2">
+                        <Badge
+                            variant="outline"
+                            className={`w-16 justify-center ${
+                                isManual
+                                    ? "border-success/40 bg-success/10 text-success"
+                                    : "border-info/40 bg-info/10 text-info"
+                            }`}
+                        >
+                            {isManual ? "Manual" : "Auto"}
+                        </Badge>
+                        <SheetTitle>Backup Details</SheetTitle>
+                    </div>
+                    <SheetDescription>
+                        {backup ? formatDateTime(backup.timestamp) : ""}
+                    </SheetDescription>
+                </SheetHeader>
+
+                {backup && (
+                    <div className="flex-1 flex flex-col gap-4 min-h-0">
+                        <div className="border border-border px-3 py-2">
+                            <DetailRow
+                                label="Created"
+                                value={getRelativeTime(backup.timestamp)}
+                            />
+                            <DetailRow
+                                label="Size"
+                                value={formatFileSize(backup.size)}
+                            />
+                            <DetailRow
+                                label="Filename"
+                                value={
+                                    <span className="font-mono break-all">
+                                        {backup.filename}
+                                    </span>
+                                }
+                            />
+                        </div>
+
+                        {isPeeking ? (
+                            <div className="flex items-center justify-center py-8">
+                                <LoadingSpinner text="Reading backup..." />
+                            </div>
+                        ) : peekError ? (
+                            <p className="text-xs text-destructive">
+                                {peekError}
+                            </p>
+                        ) : info ? (
+                            <>
+                                <div className="border border-border px-3 py-2">
+                                    <DetailRow
+                                        label="Certificates"
+                                        value={info.certificate_count}
+                                    />
+                                    <DetailRow
+                                        label="CA name"
+                                        value={info.ca_name || "—"}
+                                    />
+                                    <DetailRow
+                                        label="Schema version"
+                                        value={info.schema_version}
+                                    />
+                                    <DetailRow
+                                        label="Security keys"
+                                        value={
+                                            info.has_security_keys
+                                                ? "Yes"
+                                                : "No"
+                                        }
+                                    />
+                                </div>
+
+                                <div className="flex-1 flex flex-col min-h-0">
+                                    <p className="text-xs font-medium text-foreground mb-2">
+                                        Certificates
+                                    </p>
+                                    {info.certificates &&
+                                    info.certificates.length > 0 ? (
+                                        <div className="flex-1 space-y-2 overflow-y-auto">
+                                            {info.certificates.map((cert) => (
+                                                <div
+                                                    key={cert.hostname}
+                                                    className="border border-border px-3 py-2"
+                                                >
+                                                    <div className="flex items-center justify-between gap-2">
+                                                        <p className="text-xs font-mono font-medium text-foreground truncate">
+                                                            {cert.hostname}
+                                                        </p>
+                                                        <StatusBadge
+                                                            status={cert.status}
+                                                        />
+                                                    </div>
+                                                    <p className="mt-1 text-xs text-muted-foreground">
+                                                        Created:{" "}
+                                                        {formatDate(
+                                                            cert.created_at,
+                                                        )}
+                                                    </p>
+                                                    {cert.expires_at && (
+                                                        <p className="text-xs text-muted-foreground">
+                                                            Expires:{" "}
+                                                            {formatDate(
+                                                                cert.expires_at,
+                                                            )}
+                                                        </p>
+                                                    )}
+                                                    {cert.key_size ? (
+                                                        <p className="text-xs text-muted-foreground">
+                                                            Key Size:{" "}
+                                                            {cert.key_size} bits
+                                                        </p>
+                                                    ) : null}
+                                                    {cert.sans &&
+                                                        cert.sans.length > 0 && (
+                                                            <div className="mt-1 text-xs text-muted-foreground">
+                                                                <span className="font-medium">
+                                                                    SANs
+                                                                </span>
+                                                                <ul className="mt-0.5 list-disc pl-4 space-y-0.5">
+                                                                    {cert.sans.map(
+                                                                        (san) => (
+                                                                            <li
+                                                                                key={
+                                                                                    san
+                                                                                }
+                                                                                className="break-all"
+                                                                            >
+                                                                                {
+                                                                                    san
+                                                                                }
+                                                                            </li>
+                                                                        ),
+                                                                    )}
+                                                                </ul>
+                                                            </div>
+                                                        )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    ) : (
+                                        <EmptyState
+                                            icon={
+                                                <HugeiconsIcon
+                                                    icon={DatabaseIcon}
+                                                    className="size-10"
+                                                    strokeWidth={1.5}
+                                                />
+                                            }
+                                            title="No certificates"
+                                            description="This backup contains no certificates."
+                                        />
+                                    )}
+                                </div>
+                            </>
+                        ) : null}
+                    </div>
+                )}
+
+                <Separator />
+                <SheetFooter className="flex-row justify-end">
+                    <AdminGatedButton
+                        variant="outline"
+                        size="sm"
+                        disabled={isLoading || !backup}
+                        onClick={() => backup && onRestore(backup.filename)}
+                    >
+                        <HugeiconsIcon
+                            icon={DatabaseRestoreIcon}
+                            className="size-3.5 mr-1"
+                            strokeWidth={2}
+                        />
+                        Restore
+                    </AdminGatedButton>
+                    <AdminGatedButton
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:bg-destructive/10"
+                        disabled={isLoading || !backup}
+                        onClick={() => backup && onDelete(backup.filename)}
+                    >
+                        <HugeiconsIcon
+                            icon={Delete02Icon}
+                            className="size-3.5 mr-1"
+                            strokeWidth={2}
+                        />
+                        Delete
+                    </AdminGatedButton>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/frontend/src/components/settings/ConfigEditForm.tsx
+++ b/frontend/src/components/settings/ConfigEditForm.tsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { UpdateConfigRequest } from "@/types";
 import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog";
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -68,19 +68,23 @@ export function ConfigEditForm({
     };
 
     return (
-        <Dialog
+        <Sheet
             open={open}
             onOpenChange={(isOpen) => !isOpen && handleCancel()}
         >
-            <DialogContent
-                className="!max-w-3xl sm:!max-w-3xl max-h-[90vh] overflow-y-auto"
-                showCloseButton={false}
+            <SheetContent
+                side="right"
+                className="top-16 bottom-0 h-[calc(100%-4rem)] sm:max-w-xl"
             >
-                <DialogHeader>
-                    <DialogTitle>Edit Configuration</DialogTitle>
-                </DialogHeader>
+                <SheetHeader>
+                    <SheetTitle>Edit Configuration</SheetTitle>
+                </SheetHeader>
 
-                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+                <form
+                    onSubmit={handleSubmit(onSubmit)}
+                    className="flex-1 flex flex-col min-h-0"
+                >
+                    <div className="flex-1 overflow-y-auto space-y-6 pr-1">
                     {/* Instance Configuration */}
                     <Card>
                         <CardHeader>
@@ -471,8 +475,10 @@ export function ConfigEditForm({
                         </CardContent>
                     </Card>
 
+                    </div>
+
                     {/* Action Buttons */}
-                    <div className="flex gap-3 pt-4 border-t">
+                    <div className="flex gap-3 pt-4 mt-4 border-t shrink-0">
                         <Button type="submit" disabled={isLoading || !isDirty}>
                             {isLoading ? "Saving..." : "Save Changes"}
                         </Button>
@@ -486,7 +492,7 @@ export function ConfigEditForm({
                         </Button>
                     </div>
                 </form>
-            </DialogContent>
-        </Dialog>
+            </SheetContent>
+        </Sheet>
     );
 }

--- a/frontend/src/components/settings/LocalBackupsCard.tsx
+++ b/frontend/src/components/settings/LocalBackupsCard.tsx
@@ -8,18 +8,17 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { AdminGatedButton } from "@/components/shared/AdminGatedButton";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { ImportCertificatesDialog } from "@/components/settings/ImportCertificatesDialog";
+import { BackupDetailsDrawer } from "@/components/settings/BackupDetailsDrawer";
 import { formatDateTime, getRelativeTime, formatFileSize } from "@/lib/theme";
 import { LocalBackupInfo } from "@/types";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
-    Delete02Icon,
-    DatabaseRestoreIcon,
     DatabaseIcon,
+    ArrowRight01Icon,
 } from "@hugeicons/core-free-icons";
 
 interface LocalBackupsCardProps {
@@ -45,6 +44,9 @@ export function LocalBackupsCard({
 }: LocalBackupsCardProps) {
     const [restoreTarget, setRestoreTarget] = useState<string | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const [detailsTarget, setDetailsTarget] = useState<LocalBackupInfo | null>(
+        null,
+    );
     const [importOpen, setImportOpen] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
 
@@ -137,7 +139,16 @@ export function LocalBackupsCard({
                             {localBackups.map((backup) => (
                                 <div
                                     key={backup.filename}
-                                    className="flex items-center justify-between rounded-none border border-border px-3 py-2"
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={() => setDetailsTarget(backup)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter" || e.key === " ") {
+                                            e.preventDefault();
+                                            setDetailsTarget(backup);
+                                        }
+                                    }}
+                                    className="flex items-center justify-between rounded-none border border-border px-3 py-2 cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                                 >
                                     <div className="flex items-center gap-3 min-w-0">
                                         <Badge
@@ -178,42 +189,11 @@ export function LocalBackupsCard({
                                             </p>
                                         </div>
                                     </div>
-                                    <div className="flex items-center gap-1 shrink-0 ml-2">
-                                        <AdminGatedButton
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={() =>
-                                                setRestoreTarget(
-                                                    backup.filename,
-                                                )
-                                            }
-                                            disabled={isLoading}
-                                        >
-                                            <HugeiconsIcon
-                                                icon={DatabaseRestoreIcon}
-                                                className="size-3.5 mr-1"
-                                                strokeWidth={2}
-                                            />
-                                            Restore
-                                        </AdminGatedButton>
-                                        <AdminGatedButton
-                                            variant="outline"
-                                            size="sm"
-                                            className="text-destructive hover:bg-destructive/10"
-                                            onClick={() =>
-                                                setDeleteTarget(
-                                                    backup.filename,
-                                                )
-                                            }
-                                            disabled={isLoading}
-                                        >
-                                            <HugeiconsIcon
-                                                icon={Delete02Icon}
-                                                className="size-3.5"
-                                                strokeWidth={2}
-                                            />
-                                        </AdminGatedButton>
-                                    </div>
+                                    <HugeiconsIcon
+                                        icon={ArrowRight01Icon}
+                                        className="size-4 shrink-0 ml-2 text-muted-foreground"
+                                        strokeWidth={2}
+                                    />
                                 </div>
                             ))}
                         </div>
@@ -244,6 +224,24 @@ export function LocalBackupsCard({
                 isLoading={isLoading}
                 onConfirm={handleDelete}
                 onCancel={() => setDeleteTarget(null)}
+            />
+
+            {/* Backup Details Drawer */}
+            <BackupDetailsDrawer
+                backup={detailsTarget}
+                open={detailsTarget !== null}
+                onOpenChange={(open) => {
+                    if (!open) setDetailsTarget(null);
+                }}
+                onRestore={(filename) => {
+                    setDetailsTarget(null);
+                    setRestoreTarget(filename);
+                }}
+                onDelete={(filename) => {
+                    setDetailsTarget(null);
+                    setDeleteTarget(filename);
+                }}
+                isLoading={isLoading}
             />
 
             {/* Import Certificates Dialog */}

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,149 @@
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+function Sheet({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "right" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background ring-foreground/10 fixed inset-y-0 z-50 flex h-full w-full flex-col gap-4 p-4 text-xs/relaxed ring-1 duration-150 data-open:animate-in data-closed:animate-out sm:max-w-md",
+          side === "right" &&
+            "right-0 data-closed:slide-out-to-right data-open:slide-in-from-right border-l border-border",
+          side === "left" &&
+            "left-0 data-closed:slide-out-to-left data-open:slide-in-from-left border-r border-border",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-xs/relaxed", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+}

--- a/frontend/src/hooks/useBackup.ts
+++ b/frontend/src/hooks/useBackup.ts
@@ -12,6 +12,7 @@ interface UseBackupReturn {
         password: string,
     ) => Promise<CertImportResult | null>;
     peekBackupInfo: (path: string) => Promise<BackupPeekInfo | null>;
+    peekLocalBackup: (filename: string) => Promise<BackupPeekInfo | null>;
     selectBackupFile: () => Promise<string | null>;
     copyToClipboard: (text: string) => Promise<void>;
     getDataDirectory: () => Promise<string | null>;
@@ -63,6 +64,18 @@ export function useBackup(): UseBackupReturn {
         setError(null);
         try {
             return await api.peekBackupInfo(path);
+        } catch (err) {
+            handleError(err);
+            return null;
+        }
+    };
+
+    const peekLocalBackup = async (
+        filename: string,
+    ): Promise<BackupPeekInfo | null> => {
+        setError(null);
+        try {
+            return await api.peekLocalBackup(filename);
         } catch (err) {
             handleError(err);
             return null;
@@ -156,6 +169,7 @@ export function useBackup(): UseBackupReturn {
         error,
         importCertificatesFromBackup,
         peekBackupInfo,
+        peekLocalBackup,
         selectBackupFile,
         copyToClipboard,
         getDataDirectory,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,6 +58,8 @@ export const api = {
     // Backup import and restore
     peekBackupInfo: (path: string) =>
         App.PeekBackupInfo(path) as Promise<BackupPeekInfo>,
+    peekLocalBackup: (filename: string) =>
+        App.PeekLocalBackup(filename) as Promise<BackupPeekInfo>,
     importCertificatesFromBackup: (path: string, password: string) =>
         App.ImportCertificatesFromBackup(path, password) as Promise<CertImportResult>,
     restoreFromBackupFile: (path: string) => App.RestoreFromBackupFile(path),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,7 @@ export type UpdateConfigRequest = models.UpdateConfigRequest;
 export type SetupDefaults = models.SetupDefaults;
 export type CertImportResult = models.CertImportResult;
 export type BackupPeekInfo = models.BackupPeekInfo;
+export type BackupCertificateInfo = models.BackupCertificateInfo;
 export type KeyValidationResult = models.KeyValidationResult;
 export type ChainCertificateInfo = models.ChainCertificateInfo;
 export type HistoryEntry = models.HistoryEntry;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -59,6 +59,8 @@ export function HasSecurityKeys():Promise<boolean>;
 
 export function ImportCertificate(arg1:models.ImportRequest):Promise<void>;
 
+export function ImportCertificatesFromBackup(arg1:string,arg2:string):Promise<models.CertImportResult>;
+
 export function IsOSKeystoreAvailable():Promise<boolean>;
 
 export function IsSetupComplete():Promise<boolean>;
@@ -80,6 +82,10 @@ export function OpenBugReport():Promise<void>;
 export function OpenDataDirectory():Promise<void>;
 
 export function OpenURL(arg1:string):Promise<void>;
+
+export function PeekBackupInfo(arg1:string):Promise<models.BackupPeekInfo>;
+
+export function PeekLocalBackup(arg1:string):Promise<models.BackupPeekInfo>;
 
 export function PreviewCertificateUpload(arg1:string,arg2:string):Promise<models.CertificateUploadPreview>;
 
@@ -105,6 +111,8 @@ export function SavePrivateKeyToFile(arg1:string):Promise<void>;
 
 export function SaveSetup(arg1:models.SetupRequest):Promise<void>;
 
+export function SelectBackupFile():Promise<string>;
+
 export function SetCertificateReadOnly(arg1:string,arg2:boolean):Promise<void>;
 
 export function SkipEncryptionKey():Promise<void>;
@@ -118,9 +126,3 @@ export function UpdateConfig(arg1:models.UpdateConfigRequest):Promise<models.Con
 export function UpdatePendingNote(arg1:string,arg2:string):Promise<void>;
 
 export function UploadCertificate(arg1:string,arg2:string):Promise<void>;
-
-export function ImportCertificatesFromBackup(arg1:string,arg2:string):Promise<models.CertImportResult>;
-
-export function PeekBackupInfo(arg1:string):Promise<models.BackupPeekInfo>;
-
-export function SelectBackupFile():Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -114,6 +114,10 @@ export function ImportCertificate(arg1) {
   return window['go']['main']['App']['ImportCertificate'](arg1);
 }
 
+export function ImportCertificatesFromBackup(arg1, arg2) {
+  return window['go']['main']['App']['ImportCertificatesFromBackup'](arg1, arg2);
+}
+
 export function IsOSKeystoreAvailable() {
   return window['go']['main']['App']['IsOSKeystoreAvailable']();
 }
@@ -156,6 +160,14 @@ export function OpenDataDirectory() {
 
 export function OpenURL(arg1) {
   return window['go']['main']['App']['OpenURL'](arg1);
+}
+
+export function PeekBackupInfo(arg1) {
+  return window['go']['main']['App']['PeekBackupInfo'](arg1);
+}
+
+export function PeekLocalBackup(arg1) {
+  return window['go']['main']['App']['PeekLocalBackup'](arg1);
 }
 
 export function PreviewCertificateUpload(arg1, arg2) {
@@ -206,6 +218,10 @@ export function SaveSetup(arg1) {
   return window['go']['main']['App']['SaveSetup'](arg1);
 }
 
+export function SelectBackupFile() {
+  return window['go']['main']['App']['SelectBackupFile']();
+}
+
 export function SetCertificateReadOnly(arg1, arg2) {
   return window['go']['main']['App']['SetCertificateReadOnly'](arg1, arg2);
 }
@@ -232,16 +248,4 @@ export function UpdatePendingNote(arg1, arg2) {
 
 export function UploadCertificate(arg1, arg2) {
   return window['go']['main']['App']['UploadCertificate'](arg1, arg2);
-}
-
-export function ImportCertificatesFromBackup(arg1, arg2) {
-  return window['go']['main']['App']['ImportCertificatesFromBackup'](arg1, arg2);
-}
-
-export function PeekBackupInfo(arg1) {
-  return window['go']['main']['App']['PeekBackupInfo'](arg1);
-}
-
-export function SelectBackupFile() {
-  return window['go']['main']['App']['SelectBackupFile']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -25,79 +25,67 @@ export namespace logger {
 
 export namespace models {
 	
+	export class BackupCertificateInfo {
+	    hostname: string;
+	    status: string;
+	    sans?: string[];
+	    key_size?: number;
+	    created_at: number;
+	    expires_at?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new BackupCertificateInfo(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.hostname = source["hostname"];
+	        this.status = source["status"];
+	        this.sans = source["sans"];
+	        this.key_size = source["key_size"];
+	        this.created_at = source["created_at"];
+	        this.expires_at = source["expires_at"];
+	    }
+	}
 	export class BackupPeekInfo {
 	    certificate_count: number;
 	    ca_name: string;
 	    has_security_keys: boolean;
 	    hostnames: string[];
+	    certificates: BackupCertificateInfo[];
 	    schema_version: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new BackupPeekInfo(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.certificate_count = source["certificate_count"];
 	        this.ca_name = source["ca_name"];
 	        this.has_security_keys = source["has_security_keys"];
 	        this.hostnames = source["hostnames"];
+	        this.certificates = this.convertValues(source["certificates"], BackupCertificateInfo);
 	        this.schema_version = source["schema_version"];
 	    }
-	}
-	export class CertImportResult {
-	    imported: number;
-	    skipped: number;
-	    conflicts?: string[];
-
-	    static createFrom(source: any = {}) {
-	        return new CertImportResult(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.imported = source["imported"];
-	        this.skipped = source["skipped"];
-	        this.conflicts = source["conflicts"];
-	    }
-	}
-	export class Config {
-	    id: number;
-	    owner_email: string;
-	    ca_name: string;
-	    hostname_suffix: string;
-	    validity_period_days: number;
-	    default_organization: string;
-	    default_organizational_unit?: string;
-	    default_city: string;
-	    default_state: string;
-	    default_country: string;
-	    default_key_size: number;
-	    is_configured: number;
-	    created_at: number;
-	    last_modified: number;
 	
-	    static createFrom(source: any = {}) {
-	        return new Config(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.id = source["id"];
-	        this.owner_email = source["owner_email"];
-	        this.ca_name = source["ca_name"];
-	        this.hostname_suffix = source["hostname_suffix"];
-	        this.validity_period_days = source["validity_period_days"];
-	        this.default_organization = source["default_organization"];
-	        this.default_organizational_unit = source["default_organizational_unit"];
-	        this.default_city = source["default_city"];
-	        this.default_state = source["default_state"];
-	        this.default_country = source["default_country"];
-	        this.default_key_size = source["default_key_size"];
-	        this.is_configured = source["is_configured"];
-	        this.created_at = source["created_at"];
-	        this.last_modified = source["last_modified"];
-	    }
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class SANEntry {
 	    value: string;
@@ -177,6 +165,22 @@ export namespace models {
 	        this.hostname = source["hostname"];
 	        this.csr = source["csr"];
 	        this.message = source["message"];
+	    }
+	}
+	export class CertImportResult {
+	    imported: number;
+	    skipped: number;
+	    conflicts?: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new CertImportResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.imported = source["imported"];
+	        this.skipped = source["skipped"];
+	        this.conflicts = source["conflicts"];
 	    }
 	}
 	export class Certificate {
@@ -339,7 +343,44 @@ export namespace models {
 	        this.pem = source["pem"];
 	    }
 	}
+	export class Config {
+	    id: number;
+	    owner_email: string;
+	    ca_name: string;
+	    hostname_suffix: string;
+	    validity_period_days: number;
+	    default_organization: string;
+	    default_organizational_unit?: string;
+	    default_city: string;
+	    default_state: string;
+	    default_country: string;
+	    default_key_size: number;
+	    is_configured: number;
+	    created_at: number;
+	    last_modified: number;
 	
+	    static createFrom(source: any = {}) {
+	        return new Config(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.owner_email = source["owner_email"];
+	        this.ca_name = source["ca_name"];
+	        this.hostname_suffix = source["hostname_suffix"];
+	        this.validity_period_days = source["validity_period_days"];
+	        this.default_organization = source["default_organization"];
+	        this.default_organizational_unit = source["default_organizational_unit"];
+	        this.default_city = source["default_city"];
+	        this.default_state = source["default_state"];
+	        this.default_country = source["default_country"];
+	        this.default_key_size = source["default_key_size"];
+	        this.is_configured = source["is_configured"];
+	        this.created_at = source["created_at"];
+	        this.last_modified = source["last_modified"];
+	    }
+	}
 	export class ExportOptions {
 	    certificate: boolean;
 	    chain: boolean;

--- a/internal/models/certificate.go
+++ b/internal/models/certificate.go
@@ -106,11 +106,23 @@ type CertImportResult struct {
 
 // BackupPeekInfo represents a summary of a backup file's contents
 type BackupPeekInfo struct {
-	CertificateCount int      `json:"certificate_count"`
-	CAName           string   `json:"ca_name"`
-	HasSecurityKeys  bool     `json:"has_security_keys"`
-	Hostnames        []string `json:"hostnames"`
-	SchemaVersion    int      `json:"schema_version"`
+	CertificateCount int                     `json:"certificate_count"`
+	CAName           string                  `json:"ca_name"`
+	HasSecurityKeys  bool                    `json:"has_security_keys"`
+	Hostnames        []string                `json:"hostnames"`
+	Certificates     []BackupCertificateInfo `json:"certificates"`
+	SchemaVersion    int                     `json:"schema_version"`
+}
+
+// BackupCertificateInfo represents a single certificate inside a backup file,
+// with the same display fields as the dashboard certificate list.
+type BackupCertificateInfo struct {
+	Hostname  string   `json:"hostname"`
+	Status    string   `json:"status"` // computed: pending/active/expiring/expired
+	SANs      []string `json:"sans,omitempty"`
+	KeySize   int      `json:"key_size,omitempty"`
+	CreatedAt int64    `json:"created_at"`
+	ExpiresAt *int64   `json:"expires_at,omitempty"`
 }
 
 // LocalBackupInfo represents metadata about a local database backup file


### PR DESCRIPTION
## Backup details drawer

> **Stacked on #85** (base: `feat/master-key-wrapping`). Review/merge after #85 lands — the GitHub diff will narrow to just these changes once #85 is merged.

Adds a right-side **drawer** to inspect a local backup *before* restoring or deleting it. Clicking a backup row opens the drawer, which live-peeks the backup DB and shows its metadata plus a per-certificate list (status, SANs, created/expires, key size) matching the dashboard.

### Backend
- `PeekLocalBackup(filename)` — filename-safe peek of a local backup file (reuses `RestoreLocalBackup`'s prefix/traversal validation and the extracted `peekBackupAtPath` helper).
- `readBackupCertificates` — parses each backup's cert/CSR (public data only — no unlock needed) for status / SANs / key size; new `BackupCertificateInfo` model.

### Frontend
- New shadcn-style **`Sheet`** primitive (radix-ui Dialog, squared design, right side).
- **`BackupDetailsDrawer`** — metadata grid + fill-height certificate list (status badge, SANs as a list, Created/Expires/Key Size each on their own line). Clears the custom title bar (`top-16`).
- Backup rows are click/keyboard-openable with a chevron; the inline Restore/Delete moved into the drawer.
- Also migrated the **Edit CA Configuration** modal to the same drawer (11-field form scrolls with pinned Save/Cancel).

### Verification
`go vet` + `go test ./...` green (added `PeekLocalBackup` + per-cert-field tests); frontend `typecheck` + `lint` + production build pass. Verified live against a seeded demo (3 active / 2 pending + a pending cert with SANs): drawer renders metadata, the SANs list, status badges, and the Edit Config drawer scrolls with pinned actions.
