### PR TITLE
fix: global transaction support + SQLite integrity hardening (closes #87)

### DIFF
--- a/app_backup_import.go
+++ b/app_backup_import.go
@@ -258,69 +258,76 @@ func (a *App) ImportCertificatesFromBackup(backupPath string, backupPassword str
 	database := a.db
 	a.mu.RUnlock()
 
-	for _, cert := range certs {
-		certLog := log.With(slog.String("hostname", cert.hostname))
+	// Wrap the whole import in one transaction: either every non-conflicting
+	// certificate is inserted, or none are. A failure midway (e.g. a corrupt
+	// key on cert N) rolls back the certs already inserted in this run.
+	if err := database.WithTx(a.ctx, func(q *dbsqlc.Queries) error {
+		for _, cert := range certs {
+			certLog := log.With(slog.String("hostname", cert.hostname))
 
-		// Check for hostname conflicts
-		exists, err := database.Queries().CertificateExists(a.ctx, cert.hostname)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check certificate existence for %s: %w", cert.hostname, err)
-		}
-		if exists == 1 {
-			certLog.Debug("skipping duplicate hostname")
-			result.Skipped++
-			result.Conflicts = append(result.Conflicts, cert.hostname)
-			continue
-		}
-
-		// Re-encrypt keys: decrypt with backup master key, encrypt with current master key
-		var newEncryptedKey []byte
-		if len(cert.encryptedKey) > 0 {
-			plaintext, err := crypto.DecryptPrivateKey(cert.encryptedKey, backupMasterKey)
+			// Check for hostname conflicts
+			exists, err := q.CertificateExists(a.ctx, cert.hostname)
 			if err != nil {
-				certLog.Error("failed to decrypt private key from backup", logger.Err(err))
-				return nil, fmt.Errorf("failed to decrypt private key for %s: %w", cert.hostname, err)
+				return fmt.Errorf("failed to check certificate existence for %s: %w", cert.hostname, err)
 			}
-			newEncryptedKey, err = crypto.EncryptPrivateKey(plaintext, currentMasterKey)
-			crypto.Zero(plaintext)
-			if err != nil {
-				return nil, fmt.Errorf("failed to re-encrypt private key for %s: %w", cert.hostname, err)
+			if exists == 1 {
+				certLog.Debug("skipping duplicate hostname")
+				result.Skipped++
+				result.Conflicts = append(result.Conflicts, cert.hostname)
+				continue
 			}
-		}
 
-		var newPendingEncryptedKey []byte
-		if len(cert.pendingEncryptedKey) > 0 {
-			plaintext, err := crypto.DecryptPrivateKey(cert.pendingEncryptedKey, backupMasterKey)
-			if err != nil {
-				certLog.Error("failed to decrypt pending private key from backup", logger.Err(err))
-				return nil, fmt.Errorf("failed to decrypt pending private key for %s: %w", cert.hostname, err)
+			// Re-encrypt keys: decrypt with backup master key, encrypt with current master key
+			var newEncryptedKey []byte
+			if len(cert.encryptedKey) > 0 {
+				plaintext, err := crypto.DecryptPrivateKey(cert.encryptedKey, backupMasterKey)
+				if err != nil {
+					certLog.Error("failed to decrypt private key from backup", logger.Err(err))
+					return fmt.Errorf("failed to decrypt private key for %s: %w", cert.hostname, err)
+				}
+				newEncryptedKey, err = crypto.EncryptPrivateKey(plaintext, currentMasterKey)
+				crypto.Zero(plaintext)
+				if err != nil {
+					return fmt.Errorf("failed to re-encrypt private key for %s: %w", cert.hostname, err)
+				}
 			}
-			newPendingEncryptedKey, err = crypto.EncryptPrivateKey(plaintext, currentMasterKey)
-			crypto.Zero(plaintext)
-			if err != nil {
-				return nil, fmt.Errorf("failed to re-encrypt pending private key for %s: %w", cert.hostname, err)
+
+			var newPendingEncryptedKey []byte
+			if len(cert.pendingEncryptedKey) > 0 {
+				plaintext, err := crypto.DecryptPrivateKey(cert.pendingEncryptedKey, backupMasterKey)
+				if err != nil {
+					certLog.Error("failed to decrypt pending private key from backup", logger.Err(err))
+					return fmt.Errorf("failed to decrypt pending private key for %s: %w", cert.hostname, err)
+				}
+				newPendingEncryptedKey, err = crypto.EncryptPrivateKey(plaintext, currentMasterKey)
+				crypto.Zero(plaintext)
+				if err != nil {
+					return fmt.Errorf("failed to re-encrypt pending private key for %s: %w", cert.hostname, err)
+				}
 			}
-		}
 
-		// Insert into current database, preserving the backup's original created_at
-		err = database.Queries().ImportCertificate(a.ctx, dbsqlc.ImportCertificateParams{
-			Hostname:                   cert.hostname,
-			EncryptedPrivateKey:        newEncryptedKey,
-			PendingCsrPem:              cert.pendingCSR,
-			PendingEncryptedPrivateKey: newPendingEncryptedKey,
-			CertificatePem:             cert.certificatePEM,
-			CreatedAt:                  cert.createdAt,
-			ExpiresAt:                  cert.expiresAt,
-			Note:                       cert.note,
-			PendingNote:                cert.pendingNote,
-			ReadOnly:                   cert.readOnly,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to insert certificate %s: %w", cert.hostname, err)
-		}
+			// Insert into current database, preserving the backup's original created_at
+			if err := q.ImportCertificate(a.ctx, dbsqlc.ImportCertificateParams{
+				Hostname:                   cert.hostname,
+				EncryptedPrivateKey:        newEncryptedKey,
+				PendingCsrPem:              cert.pendingCSR,
+				PendingEncryptedPrivateKey: newPendingEncryptedKey,
+				CertificatePem:             cert.certificatePEM,
+				CreatedAt:                  cert.createdAt,
+				ExpiresAt:                  cert.expiresAt,
+				Note:                       cert.note,
+				PendingNote:                cert.pendingNote,
+				ReadOnly:                   cert.readOnly,
+			}); err != nil {
+				return fmt.Errorf("failed to insert certificate %s: %w", cert.hostname, err)
+			}
 
-		certLog.Debug("certificate imported")
-		result.Imported++
+			certLog.Debug("certificate imported")
+			result.Imported++
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	log.Info("certificate import completed",

--- a/app_backup_import_test.go
+++ b/app_backup_import_test.go
@@ -409,6 +409,43 @@ func TestImportCertificates_Success(t *testing.T) {
 	}
 }
 
+func TestImportCertificates_RollsBackOnFailure(t *testing.T) {
+	// Certs are inserted in slice (rowid) order; corrupt the LAST one so the
+	// first two are inserted within the transaction before the failure.
+	backupPath, _ := createTestBackupDB(t, testBackupDBOpts{
+		hostnames: []string{"keep1.example.com", "keep2.example.com", "corrupt.example.com"},
+		password:  testPassword,
+	})
+
+	// Truncate the corrupt cert's encrypted key so re-encryption fails mid-loop.
+	bdb, err := sql.Open("sqlite", backupPath)
+	if err != nil {
+		t.Fatalf("open backup: %v", err)
+	}
+	if _, err := bdb.Exec("UPDATE certificates SET encrypted_private_key = ? WHERE hostname = ?",
+		[]byte{0x00, 0x01, 0x02}, "corrupt.example.com"); err != nil {
+		t.Fatalf("corrupt key: %v", err)
+	}
+	bdb.Close()
+
+	app := setupUnlockedApp(t)
+
+	if _, err := app.ImportCertificatesFromBackup(backupPath, testPassword); err == nil {
+		t.Fatal("expected import to fail on the corrupt certificate")
+	}
+
+	// The transaction must have rolled back: none of the certs persisted.
+	for _, hostname := range []string{"keep1.example.com", "keep2.example.com", "corrupt.example.com"} {
+		exists, err := app.db.Queries().CertificateExists(app.ctx, hostname)
+		if err != nil {
+			t.Fatalf("CertificateExists(%s): %v", hostname, err)
+		}
+		if exists != 0 {
+			t.Fatalf("expected %s to be rolled back, but it persisted", hostname)
+		}
+	}
+}
+
 func TestImportCertificates_ReEncryptsKeys(t *testing.T) {
 	backupPath, backupMasterKey := createTestBackupDB(t, testBackupDBOpts{
 		hostnames: []string{"reencrypt.example.com"},

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -33,11 +35,21 @@ func NewDatabase(dataDir string) (*Database, error) {
 
 	var dbPath string
 
+	// Connection pragmas. modernc.org/sqlite applies each `_pragma=` on every new
+	// connection (mattn-style `_journal_mode=WAL` is silently ignored by this
+	// driver, which is why WAL/foreign-keys were previously never enabled).
+	//   - foreign_keys(1): enforce ON DELETE CASCADE (certificate_history)
+	//   - busy_timeout(5000): wait on a held lock instead of failing immediately
+	//   - journal_mode(WAL): readers don't block the writer (file DBs only)
+	// _txlock=immediate starts every transaction as a writer, avoiding the
+	// SQLITE_BUSY deadlock when a deferred read transaction upgrades to a write.
+	commonPragmas := "_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_txlock=immediate"
+
 	// Check if in-memory mode is requested (for testing)
 	if dataDir == ":memory:" {
-		// Use shared memory mode so migrations persist across connections
-		// WAL mode doesn't apply to in-memory databases
-		dbPath = "file::memory:?cache=shared"
+		// Use shared memory mode so migrations persist across connections.
+		// WAL mode doesn't apply to in-memory databases.
+		dbPath = "file::memory:?cache=shared&" + commonPragmas
 		log.Debug("using in-memory database")
 	} else {
 		// Ensure data directory exists
@@ -45,8 +57,7 @@ func NewDatabase(dataDir string) (*Database, error) {
 			log.Error("failed to create data directory", logger.Err(err))
 			return nil, fmt.Errorf("failed to create data directory: %w", err)
 		}
-		// Construct database path with WAL mode for file-based databases
-		dbPath = filepath.Join(dataDir, "certificates.db") + "?_journal_mode=WAL"
+		dbPath = filepath.Join(dataDir, "certificates.db") + "?_pragma=journal_mode(WAL)&" + commonPragmas
 		log.Debug("database path", slog.String("path", dbPath))
 	}
 
@@ -56,6 +67,16 @@ func NewDatabase(dataDir string) (*Database, error) {
 		log.Error("failed to open database", logger.Err(err))
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
+	// SQLite allows only one writer at a time. Serializing all access through a
+	// single connection eliminates "database is locked" errors entirely — the
+	// right trade-off for a local single-user desktop app. Keeping that one
+	// connection alive (no idle/lifetime reaping) is also required so the
+	// shared-cache in-memory database used in tests is never dropped.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxIdleTime(0)
+	db.SetConnMaxLifetime(0)
 
 	// Test connection
 	if err := db.Ping(); err != nil {
@@ -178,6 +199,38 @@ func (d *Database) Queries() *sqlc.Queries {
 // GetDB returns the underlying database connection for transaction support
 func (d *Database) GetDB() *sql.DB {
 	return d.db
+}
+
+// WithTx runs fn inside a single database transaction, passing transaction-scoped
+// queries. The transaction is committed if fn returns nil, and rolled back if fn
+// returns an error or panics (the panic is re-raised after rollback). Use it for
+// any operation that performs more than one mutation so a mid-operation failure
+// can never leave a partial/inconsistent state.
+func (d *Database) WithTx(ctx context.Context, fn func(q *sqlc.Queries) error) (err error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+		if err != nil {
+			if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+				err = errors.Join(err, fmt.Errorf("rollback: %w", rbErr))
+			}
+		}
+	}()
+
+	if err = fn(d.queries.WithTx(tx)); err != nil {
+		return err
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+	return nil
 }
 
 // ensureDir ensures a directory exists, creating it if necessary

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -1,8 +1,134 @@
 package db
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
 	"testing"
+
+	"paddockcontrol-desktop/internal/db/sqlc"
 )
+
+func TestConnectionPragmas(t *testing.T) {
+	// File-based DB so journal_mode(WAL) applies (it doesn't to :memory:).
+	database, err := NewDatabase(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	defer database.Close()
+
+	checks := map[string]string{
+		"journal_mode": "wal",
+		"foreign_keys": "1",
+		"busy_timeout": "5000",
+	}
+	for pragma, want := range checks {
+		var got string
+		if err := database.DB().QueryRow("PRAGMA " + pragma).Scan(&got); err != nil {
+			t.Fatalf("PRAGMA %s: %v", pragma, err)
+		}
+		if got != want {
+			t.Errorf("PRAGMA %s = %q, want %q", pragma, got, want)
+		}
+	}
+}
+
+func TestForeignKeyCascade(t *testing.T) {
+	database, err := NewDatabase(":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	q := database.Queries()
+
+	if err := q.CreateCertificate(ctx, sqlc.CreateCertificateParams{Hostname: "h.test.local"}); err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	if err := q.AddHistoryEntry(ctx, sqlc.AddHistoryEntryParams{Hostname: "h.test.local", EventType: "x", Message: "m"}); err != nil {
+		t.Fatalf("AddHistoryEntry: %v", err)
+	}
+
+	var hist int
+	_ = database.DB().QueryRow("SELECT COUNT(*) FROM certificate_history WHERE hostname='h.test.local'").Scan(&hist)
+	if hist != 1 {
+		t.Fatalf("expected 1 history row before delete, got %d", hist)
+	}
+
+	if err := q.DeleteCertificate(ctx, "h.test.local"); err != nil {
+		t.Fatalf("DeleteCertificate: %v", err)
+	}
+
+	_ = database.DB().QueryRow("SELECT COUNT(*) FROM certificate_history WHERE hostname='h.test.local'").Scan(&hist)
+	if hist != 0 {
+		t.Fatalf("ON DELETE CASCADE not enforced: %d orphan history rows remain", hist)
+	}
+}
+
+func TestWithTx_CommitsOnSuccess(t *testing.T) {
+	database, _ := newMemDB(t)
+	err := database.WithTx(context.Background(), func(q *sqlc.Queries) error {
+		return q.CreateCertificate(context.Background(), sqlc.CreateCertificateParams{Hostname: "ok.test.local"})
+	})
+	if err != nil {
+		t.Fatalf("WithTx: %v", err)
+	}
+	if !certExists(t, database, "ok.test.local") {
+		t.Fatal("committed certificate not found")
+	}
+}
+
+func TestWithTx_RollsBackOnError(t *testing.T) {
+	database, _ := newMemDB(t)
+	sentinel := errors.New("boom")
+	err := database.WithTx(context.Background(), func(q *sqlc.Queries) error {
+		if e := q.CreateCertificate(context.Background(), sqlc.CreateCertificateParams{Hostname: "bad.test.local"}); e != nil {
+			return e
+		}
+		return sentinel // force rollback after a successful write
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if certExists(t, database, "bad.test.local") {
+		t.Fatal("write was not rolled back")
+	}
+}
+
+func TestWithTx_RollsBackOnPanic(t *testing.T) {
+	database, _ := newMemDB(t)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic to propagate")
+		}
+		if certExists(t, database, "panic.test.local") {
+			t.Fatal("write was not rolled back on panic")
+		}
+	}()
+	_ = database.WithTx(context.Background(), func(q *sqlc.Queries) error {
+		_ = q.CreateCertificate(context.Background(), sqlc.CreateCertificateParams{Hostname: "panic.test.local"})
+		panic("boom")
+	})
+}
+
+func newMemDB(t *testing.T) (*Database, string) {
+	t.Helper()
+	database, err := NewDatabase(":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return database, filepath.Join(t.TempDir(), "x")
+}
+
+func certExists(t *testing.T, d *Database, hostname string) bool {
+	t.Helper()
+	n, err := d.Queries().CertificateExists(context.Background(), hostname)
+	if err != nil {
+		t.Fatalf("CertificateExists: %v", err)
+	}
+	return n == 1
+}
 
 func TestResetWithMigrations(t *testing.T) {
 	// Create in-memory database

--- a/internal/services/certificate_generator.go
+++ b/internal/services/certificate_generator.go
@@ -114,45 +114,45 @@ func (s *CertificateService) GenerateCSR(ctx context.Context, req models.CSRRequ
 	}
 	log.Debug("profile: EncryptPrivateKey", slog.Duration("duration", time.Since(t)))
 
-	// Store in database
+	// Store the CSR and record the history event atomically.
 	t = time.Now()
-	if req.IsRenewal {
-		// Update existing certificate with pending renewal
-		err = s.db.Queries().UpdatePendingCSR(ctx, sqlc.UpdatePendingCSRParams{
-			Hostname:                   req.Hostname,
-			PendingCsrPem:              sql.NullString{String: string(csrPEM), Valid: true},
-			PendingEncryptedPrivateKey: encryptedKey,
-			PendingNote:                sql.NullString{String: req.Note, Valid: req.Note != ""},
-		})
-	} else {
-		// Create new certificate record
-		// Key stored in pending column — ActivateCertificate moves it to active on upload
-		err = s.db.Queries().CreateCertificate(ctx, sqlc.CreateCertificateParams{
-			Hostname:                   req.Hostname,
-			PendingEncryptedPrivateKey: encryptedKey,
-			PendingCsrPem:              sql.NullString{String: string(csrPEM), Valid: true},
-			Note:                       sql.NullString{String: req.Note, Valid: req.Note != ""},
-			ReadOnly:                   0,
-		})
-	}
-	log.Debug("profile: Database write", slog.Duration("duration", time.Since(t)))
-
-	if err != nil {
-		log.Error("failed to store CSR", logger.Err(err))
-		return nil, fmt.Errorf("failed to store CSR: %w", err)
-	}
-
-	// Log history entry
 	eventType := models.EventCSRGenerated
 	message := fmt.Sprintf("CSR generated (%d-bit key, %d SANs)", req.KeySize, len(req.SANs))
 	if req.IsRenewal {
 		eventType = models.EventCSRRegenerated
 		message = fmt.Sprintf("CSR regenerated for renewal (%d-bit key, %d SANs)", req.KeySize, len(req.SANs))
 	}
-	if err := s.history.LogEvent(ctx, req.Hostname, eventType, message); err != nil {
-		log.Warn("failed to log history entry", logger.Err(err))
-		// Don't fail the operation for history logging errors
+
+	if err = s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if req.IsRenewal {
+			// Update existing certificate with pending renewal
+			if err := q.UpdatePendingCSR(ctx, sqlc.UpdatePendingCSRParams{
+				Hostname:                   req.Hostname,
+				PendingCsrPem:              sql.NullString{String: string(csrPEM), Valid: true},
+				PendingEncryptedPrivateKey: encryptedKey,
+				PendingNote:                sql.NullString{String: req.Note, Valid: req.Note != ""},
+			}); err != nil {
+				return fmt.Errorf("failed to store CSR: %w", err)
+			}
+		} else {
+			// Create new certificate record
+			// Key stored in pending column — ActivateCertificate moves it to active on upload
+			if err := q.CreateCertificate(ctx, sqlc.CreateCertificateParams{
+				Hostname:                   req.Hostname,
+				PendingEncryptedPrivateKey: encryptedKey,
+				PendingCsrPem:              sql.NullString{String: string(csrPEM), Valid: true},
+				Note:                       sql.NullString{String: req.Note, Valid: req.Note != ""},
+				ReadOnly:                   0,
+			}); err != nil {
+				return fmt.Errorf("failed to store CSR: %w", err)
+			}
+		}
+		return s.history.LogEventTx(ctx, q, req.Hostname, eventType, message)
+	}); err != nil {
+		log.Error("failed to store CSR", logger.Err(err))
+		return nil, err
 	}
+	log.Debug("profile: Database write", slog.Duration("duration", time.Since(t)))
 
 	log.Info("CSR generated successfully",
 		slog.Duration("total_duration", time.Since(start)),

--- a/internal/services/certificate_manager.go
+++ b/internal/services/certificate_manager.go
@@ -128,25 +128,23 @@ func (s *CertificateService) GetCertificate(ctx context.Context, hostname string
 
 // DeleteCertificate deletes a certificate
 func (s *CertificateService) DeleteCertificate(ctx context.Context, hostname string) error {
-	// Check read-only
-	cert, err := s.db.Queries().GetCertificateByHostname(ctx, hostname)
-	if err != nil {
-		return fmt.Errorf("failed to get certificate: %w", err)
-	}
-
-	if cert.ReadOnly == 1 {
-		return fmt.Errorf("certificate is read-only and cannot be deleted")
-	}
-
-	// Log history entry before delete (will be cascade deleted with certificate)
-	_ = s.history.LogEvent(ctx, hostname, models.EventCertificateDeleted, "Certificate deleted")
-
-	err = s.db.Queries().DeleteCertificate(ctx, hostname)
-	if err != nil {
-		return fmt.Errorf("failed to delete certificate: %w", err)
-	}
-
-	return nil
+	// Read-only check and delete run in one transaction so the guard can't be
+	// bypassed by a concurrent change between the check and the delete. The
+	// certificate's history rows are removed automatically via ON DELETE
+	// CASCADE, so no separate "deleted" history entry is recorded.
+	return s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		cert, err := q.GetCertificateByHostname(ctx, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to get certificate: %w", err)
+		}
+		if cert.ReadOnly == 1 {
+			return fmt.Errorf("certificate is read-only and cannot be deleted")
+		}
+		if err := q.DeleteCertificate(ctx, hostname); err != nil {
+			return fmt.Errorf("failed to delete certificate: %w", err)
+		}
+		return nil
+	})
 }
 
 // ClearPendingCSR removes the pending CSR, pending private key, and pending note from a certificate
@@ -164,14 +162,13 @@ func (s *CertificateService) ClearPendingCSR(ctx context.Context, hostname strin
 		return fmt.Errorf("certificate has no pending CSR")
 	}
 
-	err = s.db.Queries().ClearPendingCSR(ctx, hostname)
-	if err != nil {
-		return fmt.Errorf("failed to clear pending CSR: %w", err)
-	}
-
-	_ = s.history.LogEvent(ctx, hostname, models.EventPendingCSRRemoved, "Pending renewal CSR cancelled")
-
-	return nil
+	// Clear the pending CSR and record the history event atomically.
+	return s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if err := q.ClearPendingCSR(ctx, hostname); err != nil {
+			return fmt.Errorf("failed to clear pending CSR: %w", err)
+		}
+		return s.history.LogEventTx(ctx, q, hostname, models.EventPendingCSRRemoved, "Pending renewal CSR cancelled")
+	})
 }
 
 // SetCertificateReadOnly sets the read-only status of a certificate
@@ -180,24 +177,23 @@ func (s *CertificateService) SetCertificateReadOnly(ctx context.Context, hostnam
 	if readOnly {
 		readOnlyValue = 1
 	}
-	err := s.db.Queries().UpdateCertificateReadOnly(ctx, sqlc.UpdateCertificateReadOnlyParams{
-		ReadOnly: readOnlyValue,
-		Hostname: hostname,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Log history entry
 	eventType := models.EventReadOnlyDisabled
 	message := "Read-only protection removed"
 	if readOnly {
 		eventType = models.EventReadOnlyEnabled
 		message = "Marked as read-only"
 	}
-	_ = s.history.LogEvent(ctx, hostname, eventType, message)
 
-	return nil
+	// Update the flag and record the history event atomically.
+	return s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if err := q.UpdateCertificateReadOnly(ctx, sqlc.UpdateCertificateReadOnlyParams{
+			ReadOnly: readOnlyValue,
+			Hostname: hostname,
+		}); err != nil {
+			return err
+		}
+		return s.history.LogEventTx(ctx, q, hostname, eventType, message)
+	})
 }
 
 // UpdateCertificateNote updates the note for a certificate

--- a/internal/services/certificate_upload.go
+++ b/internal/services/certificate_upload.go
@@ -75,21 +75,22 @@ func (s *CertificateService) UploadCertificate(ctx context.Context, hostname, ce
 	// Extract expiration date
 	expiresAt := parsedCert.NotAfter.Unix()
 
-	// Update in database
+	// Activate the certificate and record the history event atomically.
 	log.Info("activating certificate", slog.Int64("expires_at", expiresAt))
-	err = s.db.Queries().ActivateCertificate(ctx, sqlc.ActivateCertificateParams{
-		Hostname:       hostname,
-		CertificatePem: sql.NullString{String: certPEM, Valid: true},
-		ExpiresAt:      sql.NullInt64{Int64: expiresAt, Valid: true},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to activate certificate: %w", err)
-	}
-
-	// Log history entry
 	expiresDate := time.Unix(expiresAt, 0).Format("2006-01-02")
 	message := fmt.Sprintf("Certificate uploaded (expires %s)", expiresDate)
-	_ = s.history.LogEvent(ctx, hostname, models.EventCertificateUploaded, message)
+	if err = s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if err := q.ActivateCertificate(ctx, sqlc.ActivateCertificateParams{
+			Hostname:       hostname,
+			CertificatePem: sql.NullString{String: certPEM, Valid: true},
+			ExpiresAt:      sql.NullInt64{Int64: expiresAt, Valid: true},
+		}); err != nil {
+			return fmt.Errorf("failed to activate certificate: %w", err)
+		}
+		return s.history.LogEventTx(ctx, q, hostname, models.EventCertificateUploaded, message)
+	}); err != nil {
+		return err
+	}
 
 	log.Info("certificate uploaded successfully", slog.String("expires", expiresDate))
 	return nil
@@ -224,23 +225,20 @@ func (s *CertificateService) ImportCertificate(ctx context.Context, req models.I
 	// Extract expiration date
 	expiresAt := parsedCert.NotAfter.Unix()
 
-	// Store in database
-	err = s.db.Queries().CreateCertificate(ctx, sqlc.CreateCertificateParams{
-		Hostname:            hostname,
-		EncryptedPrivateKey: encryptedKey,
-		CertificatePem:      sql.NullString{String: req.CertificatePEM, Valid: true},
-		ExpiresAt:           sql.NullInt64{Int64: expiresAt, Valid: true},
-		Note:                sql.NullString{String: req.Note, Valid: req.Note != ""},
-		ReadOnly:            0,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to import certificate: %w", err)
-	}
-
-	// Log history entry
+	// Store the certificate and record the history event atomically.
 	expiresDate := time.Unix(expiresAt, 0).Format("2006-01-02")
 	message := fmt.Sprintf("Certificate imported (expires %s)", expiresDate)
-	_ = s.history.LogEvent(ctx, hostname, models.EventCertificateImported, message)
-
-	return nil
+	return s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if err := q.CreateCertificate(ctx, sqlc.CreateCertificateParams{
+			Hostname:            hostname,
+			EncryptedPrivateKey: encryptedKey,
+			CertificatePem:      sql.NullString{String: req.CertificatePEM, Valid: true},
+			ExpiresAt:           sql.NullInt64{Int64: expiresAt, Valid: true},
+			Note:                sql.NullString{String: req.Note, Valid: req.Note != ""},
+			ReadOnly:            0,
+		}); err != nil {
+			return fmt.Errorf("failed to import certificate: %w", err)
+		}
+		return s.history.LogEventTx(ctx, q, hostname, models.EventCertificateImported, message)
+	})
 }

--- a/internal/services/history_service.go
+++ b/internal/services/history_service.go
@@ -21,9 +21,19 @@ func NewHistoryService(database *db.Database) *HistoryService {
 	}
 }
 
-// LogEvent adds a new history entry for a certificate
+// LogEvent adds a new history entry for a certificate.
 func (s *HistoryService) LogEvent(ctx context.Context, hostname, eventType, message string) error {
-	return s.db.Queries().AddHistoryEntry(ctx, sqlc.AddHistoryEntryParams{
+	return logEvent(ctx, s.db.Queries(), hostname, eventType, message)
+}
+
+// LogEventTx adds a history entry using the provided transaction-scoped queries
+// so it commits atomically with the caller's other writes.
+func (s *HistoryService) LogEventTx(ctx context.Context, q *sqlc.Queries, hostname, eventType, message string) error {
+	return logEvent(ctx, q, hostname, eventType, message)
+}
+
+func logEvent(ctx context.Context, q *sqlc.Queries, hostname, eventType, message string) error {
+	return q.AddHistoryEntry(ctx, sqlc.AddHistoryEntryParams{
 		Hostname:  hostname,
 		EventType: eventType,
 		Message:   message,

--- a/internal/services/history_service_test.go
+++ b/internal/services/history_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"paddockcontrol-desktop/internal/db"
+	"paddockcontrol-desktop/internal/db/sqlc"
 	"paddockcontrol-desktop/internal/models"
 )
 
@@ -18,9 +19,23 @@ func setupHistoryService(t *testing.T) (*HistoryService, *db.Database) {
 	return NewHistoryService(database), database
 }
 
+// seedCert inserts a minimal certificate so history rows for it satisfy the
+// certificate_history -> certificates foreign key (enforced now that
+// foreign_keys is enabled). In production, history is always logged for an
+// existing certificate.
+func seedCert(t *testing.T, database *db.Database, hostname string) {
+	t.Helper()
+	if err := database.Queries().CreateCertificate(context.Background(), sqlc.CreateCertificateParams{
+		Hostname: hostname,
+	}); err != nil {
+		t.Fatalf("failed to seed certificate %q: %v", hostname, err)
+	}
+}
+
 func TestLogEvent_Success(t *testing.T) {
-	svc, _ := setupHistoryService(t)
+	svc, database := setupHistoryService(t)
 	ctx := context.Background()
+	seedCert(t, database, "test.example.com")
 
 	err := svc.LogEvent(ctx, "test.example.com", models.EventCSRGenerated, "CSR generated")
 	if err != nil {
@@ -46,9 +61,10 @@ func TestLogEvent_Success(t *testing.T) {
 }
 
 func TestGetHistory_ReturnsEntries(t *testing.T) {
-	svc, _ := setupHistoryService(t)
+	svc, database := setupHistoryService(t)
 	ctx := context.Background()
 	hostname := "test.example.com"
+	seedCert(t, database, hostname)
 
 	// Log multiple events
 	events := []struct {
@@ -75,9 +91,10 @@ func TestGetHistory_ReturnsEntries(t *testing.T) {
 }
 
 func TestGetHistory_DefaultLimit(t *testing.T) {
-	svc, _ := setupHistoryService(t)
+	svc, database := setupHistoryService(t)
 	ctx := context.Background()
 	hostname := "test.example.com"
+	seedCert(t, database, hostname)
 
 	// Log a few events
 	for i := 0; i < 3; i++ {
@@ -105,9 +122,10 @@ func TestGetHistory_DefaultLimit(t *testing.T) {
 }
 
 func TestGetHistory_CustomLimit(t *testing.T) {
-	svc, _ := setupHistoryService(t)
+	svc, database := setupHistoryService(t)
 	ctx := context.Background()
 	hostname := "test.example.com"
+	seedCert(t, database, hostname)
 
 	for i := 0; i < 5; i++ {
 		if err := svc.LogEvent(ctx, hostname, models.EventCSRGenerated, "event"); err != nil {
@@ -138,8 +156,10 @@ func TestGetHistory_EmptyHistory(t *testing.T) {
 }
 
 func TestGetHistory_FiltersByHostname(t *testing.T) {
-	svc, _ := setupHistoryService(t)
+	svc, database := setupHistoryService(t)
 	ctx := context.Background()
+	seedCert(t, database, "host1.example.com")
+	seedCert(t, database, "host2.example.com")
 
 	// Log events for two different hostnames
 	if err := svc.LogEvent(ctx, "host1.example.com", models.EventCSRGenerated, "event 1"); err != nil {

--- a/internal/services/setup_service.go
+++ b/internal/services/setup_service.go
@@ -50,30 +50,31 @@ func (s *SetupService) SetupFromScratch(ctx context.Context, req models.SetupReq
 	}
 	log.Debug("setup request validated")
 
-	// Create config record in database
-	err := s.db.Queries().CreateConfig(ctx, sqlc.CreateConfigParams{
-		OwnerEmail:                req.OwnerEmail,
-		CaName:                    req.CAName,
-		HostnameSuffix:            req.HostnameSuffix,
-		DefaultOrganization:       req.DefaultOrganization,
-		DefaultOrganizationalUnit: stringToNullString(req.DefaultOrganizationalUnit),
-		DefaultCity:               req.DefaultCity,
-		DefaultState:              req.DefaultState,
-		DefaultCountry:            req.DefaultCountry,
-		DefaultKeySize:            int64(req.DefaultKeySize),
-		ValidityPeriodDays:        int64(req.ValidityPeriodDays),
-	})
-	if err != nil {
-		log.Error("failed to create configuration", logger.Err(err))
-		return fmt.Errorf("failed to create configuration: %w", err)
-	}
-	log.Debug("configuration record created")
-
-	// Mark as configured
-	err = s.config.SetConfigured(ctx)
-	if err != nil {
-		log.Error("failed to mark as configured", logger.Err(err))
-		return fmt.Errorf("failed to mark as configured: %w", err)
+	// Create the config record and mark setup complete atomically: a failure
+	// between the two would otherwise leave a config row with is_configured=0,
+	// trapping the user in the setup wizard despite a config existing.
+	if err := s.db.WithTx(ctx, func(q *sqlc.Queries) error {
+		if err := q.CreateConfig(ctx, sqlc.CreateConfigParams{
+			OwnerEmail:                req.OwnerEmail,
+			CaName:                    req.CAName,
+			HostnameSuffix:            req.HostnameSuffix,
+			DefaultOrganization:       req.DefaultOrganization,
+			DefaultOrganizationalUnit: stringToNullString(req.DefaultOrganizationalUnit),
+			DefaultCity:               req.DefaultCity,
+			DefaultState:              req.DefaultState,
+			DefaultCountry:            req.DefaultCountry,
+			DefaultKeySize:            int64(req.DefaultKeySize),
+			ValidityPeriodDays:        int64(req.ValidityPeriodDays),
+		}); err != nil {
+			return fmt.Errorf("failed to create configuration: %w", err)
+		}
+		if err := q.SetConfigured(ctx); err != nil {
+			return fmt.Errorf("failed to mark as configured: %w", err)
+		}
+		return nil
+	}); err != nil {
+		log.Error("fresh setup failed", logger.Err(err))
+		return err
 	}
 
 	log.Info("fresh setup completed successfully")


### PR DESCRIPTION
## Global transaction support + SQLite hardening — closes #87

Issue #87 asked to wrap multi-step writes in transactions. While doing that I researched Go/SQLite transaction best practices and found the data-integrity gap was bigger than missing transactions — the connection itself was misconfigured. This PR fixes both.

### 1. The connection was silently mis-pragma'd (latent data-integrity bug)

The driver is **modernc.org/sqlite**, which ignores mattn-style DSN params. The existing `?_journal_mode=WAL` was therefore a **no-op**. Verified empirically:

```
CURRENT  DSN: journal_mode=delete  foreign_keys=0  busy_timeout=0
PROPOSED DSN: journal_mode=wal     foreign_keys=1  busy_timeout=5000
```

Consequences in production:
- **`foreign_keys=0`** → the `certificate_history → certificates ON DELETE CASCADE` was **never enforced**, leaving orphaned history rows after deletes.
- **rollback-journal (not WAL)** and **`busy_timeout=0`** → writes failed immediately on any contention.

Fix: build the DSN with modernc's `_pragma=` syntax — `journal_mode(WAL)`, `foreign_keys(1)`, `busy_timeout(5000)` — plus `_txlock=immediate` so every transaction starts as a writer (avoids the classic SQLITE_BUSY deadlock when a deferred read upgrades to a write). And `SetMaxOpenConns(1)` + no idle/lifetime reaping to serialize all access through one connection — the robust, deadlock-free choice for a single-user desktop app that eliminates "database is locked" (and keeps the shared-cache in-memory test DB alive).

### 2. `Database.WithTx` helper

```go
func (d *Database) WithTx(ctx, func(q *sqlc.Queries) error) error
```
Commits on success; rolls back on error **or panic** (panic re-raised); joins any rollback error. The building block #87 asked for (sqlc's `WithTx(tx)` provides the transaction-scoped queries).

### 3. Every multi-write operation wrapped

| Operation | Was | Now |
|---|---|---|
| `ImportCertificatesFromBackup` | per-cert inserts, no tx → partial import on mid-loop failure | whole loop in one tx (all-or-nothing) |
| `SetupFromScratch` | `CreateConfig` then `SetConfigured` | atomic (no more "config exists but setup wizard loops") |
| `GenerateCSR` / upload `UploadCertificate` / `ImportCertificate` | main write + best-effort history | write + history commit together |
| `ClearPendingCSR`, `SetCertificateReadOnly` | write + best-effort history | atomic |
| `DeleteCertificate` | read-only check + log + delete | check + delete atomic (closes TOCTOU); dropped the history log that `ON DELETE CASCADE` deleted anyway |

Already-transacted (`migrateLegacyEncryption`, `ChangeEncryptionKey`) were left as-is.

### Out of scope (documented, not DB-fixable)
`EnrollOSNative` / `RemoveSecurityKey` each do **one** DB write plus an **OS-keyring** write — a DB transaction can't make cross-system state atomic. They already use ordered writes + compensating delete on failure. A keyring/DB saga could be a separate issue if stronger guarantees are wanted.

### Tests
- DB layer: asserts the three pragmas, FK cascade deletion, and `WithTx` commit/rollback/panic.
- Import: corrupts a trailing cert and asserts **none** of the batch persists (full rollback).
- Enabling FK enforcement surfaced history-service tests that logged events for non-existent certificates — they now seed the parent cert (production always logs for an existing cert).
- `go vet` + full `go test ./...` green; no deadlock under `SetMaxOpenConns(1)`, test isolation intact.

### Research basis
modernc DSN (`_pragma`/`_txlock`) from its package docs; SQLite-with-Go guidance (single connection as the key setting, `busy_timeout`, WAL, `BEGIN IMMEDIATE` for writes) from the sources below.

Sources: [modernc.org/sqlite docs](https://pkg.go.dev/modernc.org/sqlite) · [Go + SQLite best practices (Jake Gold)](https://jacob.gold/posts/go-sqlite-best-practices/) · [SQLite concurrent writes & "database is locked"](https://tenthousandmeters.com/blog/sqlite-concurrent-writes-and-database-is-locked-errors/)

Closes #87.
